### PR TITLE
fix code generator options handling

### DIFF
--- a/pynestml/codegeneration/nest_code_generator.py
+++ b/pynestml/codegeneration/nest_code_generator.py
@@ -177,7 +177,11 @@ class NESTCodeGenerator(CodeGenerator):
             # Check if the random number functions are used in the right blocks
             CoCosManager.check_co_co_nest_random_functions_legally_used(model)
 
-            if self.get_option("neuron_synapse_pairs"):
+            if Logger.has_errors(model):
+                raise Exception("Error(s) occurred during code generation")
+
+        if self.get_option("neuron_synapse_pairs"):
+            for model in synapses:
                 synapse_name_stripped = removesuffix(removesuffix(model.name.split("_with_")[0], "_"),
                                                      FrontendConfiguration.suffix)
                 # special case for NEST delay variable (state or parameter)
@@ -192,8 +196,8 @@ class NESTCodeGenerator(CodeGenerator):
                     delay_variable = self.get_option("delay_variable")[synapse_name_stripped]
                     CoCoNESTSynapseDelayNotAssignedTo.check_co_co(delay_variable, model)
 
-            if Logger.has_errors(model):
-                raise Exception("Error(s) occurred during code generation")
+                if Logger.has_errors(model):
+                    raise Exception("Error(s) occurred during code generation")
 
     def setup_printers(self):
         self._constant_printer = ConstantPrinter()

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -464,19 +464,24 @@ def process():
         Flag indicating whether errors occurred during processing
     """
 
-    # initialize and set options for transformers, code generator and builder
-    codegen_and_builder_opts = FrontendConfiguration.get_codegen_opts()
+    # initialise model transformers
+    transformers, unused_opts_transformer = transformers_from_target_name(FrontendConfiguration.get_target_platform(),
+                                                                          options=FrontendConfiguration.get_codegen_opts())
 
-    transformers, codegen_and_builder_opts = transformers_from_target_name(FrontendConfiguration.get_target_platform(),
-                                                                           options=codegen_and_builder_opts)
-
+    # initialise code generator
     code_generator = code_generator_from_target_name(FrontendConfiguration.get_target_platform())
-    codegen_and_builder_opts = code_generator.set_options(codegen_and_builder_opts)
+    unused_opts_codegen = code_generator.set_options(FrontendConfiguration.get_codegen_opts())
 
-    _builder, codegen_and_builder_opts = builder_from_target_name(FrontendConfiguration.get_target_platform(), options=codegen_and_builder_opts)
+    # initialise builder
+    _builder, unused_opts_builder = builder_from_target_name(FrontendConfiguration.get_target_platform(),
+                                                             options=FrontendConfiguration.get_codegen_opts())
 
-    if len(codegen_and_builder_opts) > 0:
-        raise CodeGeneratorOptionsException("The code generator option(s) \"" + ", ".join(codegen_and_builder_opts.keys()) + "\" do not exist.")
+    # check for unused codegen options
+    for opt_key in FrontendConfiguration.get_codegen_opts().keys():
+        if opt_key in unused_opts_transformer.keys() \
+         and opt_key in unused_opts_codegen.keys() \
+         and opt_key in unused_opts_builder.keys():
+            raise CodeGeneratorOptionsException("The code generator option \"" + opt_key + "\" does not exist.")
 
     models, errors_occurred = get_parsed_models()
 

--- a/pynestml/frontend/pynestml_frontend.py
+++ b/pynestml/frontend/pynestml_frontend.py
@@ -478,9 +478,7 @@ def process():
 
     # check for unused codegen options
     for opt_key in FrontendConfiguration.get_codegen_opts().keys():
-        if opt_key in unused_opts_transformer.keys() \
-         and opt_key in unused_opts_codegen.keys() \
-         and opt_key in unused_opts_builder.keys():
+        if opt_key in unused_opts_transformer.keys() and opt_key in unused_opts_codegen.keys() and opt_key in unused_opts_builder.keys():
             raise CodeGeneratorOptionsException("The code generator option \"" + opt_key + "\" does not exist.")
 
     models, errors_occurred = get_parsed_models()


### PR DESCRIPTION
Fixes the issue that not all code generator options were being passed to the NEST code generator, as they were already being used by the transformer(s). (``neuron_synapse_pairs`` in the code generator was always empty.) New approach is to pass all (frontend) options to transformers, codegen and builder, and only afterwards check if there were options that were not used by any of these three.